### PR TITLE
Add Get User Role API to fetch user roles by ID or list all roles

### DIFF
--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -10,5 +10,8 @@
     "User role does not exists in system": "User role does not exists in system",
     "An error occurred while verifying user role in system": "Error occurred while verifying user role in system",
     "User role registered successfully": "User role registered successfully",
-    "An error occurred while registering new user role in system": "Error occurred while registering new user role in system"
+    "An error occurred while registering new user role in system": "Error occurred while registering new user role in system",
+    "An error occurred while processing the request": "Error occurred while processing the request",
+    "No user role found": "No user role found",
+    "An error occurred while fetching user roles": "Error occurred while fetching user roles"
 }

--- a/src/controllers/system-setup-controllers/getUserRole.controller.js
+++ b/src/controllers/system-setup-controllers/getUserRole.controller.js
@@ -12,7 +12,7 @@ const getUserRoleById = async (roleId) => {
     roleId = convertPrettyStringToId(roleId);
 
     log.info(`Call db query to fetch user role details for provided id: ${roleId}`);
-    let roleDtl = await SystemDB.getUserRoleById(roleId);
+    let roleDtl = await SystemDB.getUserRole(roleId);
     if (roleDtl.rowCount === 0) {
       log.error('User role requested with the id does not exists in system');
       throw _Error(404, 'User role not found');
@@ -29,4 +29,25 @@ const getUserRoleById = async (roleId) => {
   }
 };
 
-export { getUserRoleById };
+const getAllUserRoles = async () => {
+  try {
+    log.info('Controller function to fetch all user roles process initiated');
+    log.info('Call db query to fetch all user roles');
+
+    let roleDtl = await SystemDB.getUserRole();
+    if (roleDtl.rowCount === 0) {
+      log.info('No user role available to return');
+      return _Response(204, 'No user role found', roleDtl.rows);
+    }
+
+    roleDtl = roleDtl.rows;
+    formatResponseBody(roleDtl, fieldMappings.userRoleFields);
+    log.success('User roles fetched successfully');
+    return _Response(200, 'User role found', roleDtl);
+  } catch (err) {
+    log.error('Error occurred while trying to fetch all user roles');
+    throw _Error(500, 'An error occurred while fetching user roles', err);
+  }
+};
+
+export { getUserRoleById, getAllUserRoles };

--- a/src/controllers/system-setup-controllers/index.js
+++ b/src/controllers/system-setup-controllers/index.js
@@ -1,10 +1,11 @@
 'use strict';
 
 import { verifyUserRoleExist, registerNewUserRole } from './registerUserRole.controller.js';
-import { getUserRoleById } from './getUserRole.controller.js';
+import { getUserRoleById, getAllUserRoles } from './getUserRole.controller.js';
 
 export default {
   verifyUserRoleExist,
   registerNewUserRole,
   getUserRoleById,
+  getAllUserRoles,
 };

--- a/src/db/system.db.js
+++ b/src/db/system.db.js
@@ -52,11 +52,16 @@ class SystemDB extends DBQuery {
     return db.execute(query, params);
   }
 
-  async getUserRoleById(roleId) {
-    const query = `SELECT ID, ROLE_CD, ROLE_DESC, IS_ACTIVE, IS_DEFAULT, CREATED_DATE, MODIFIED_DATE
+  async getUserRole(roleId = null) {
+    let query = `SELECT ID, ROLE_CD, ROLE_DESC, IS_ACTIVE, IS_DEFAULT, CREATED_DATE, MODIFIED_DATE
       FROM ${this.tables['USER_ROLE']}
-      WHERE ID = ? AND IS_DELETED = false;`;
-    const params = [roleId];
+      WHERE IS_DELETED = false`;
+    let params = [];
+
+    if (roleId) {
+      query += ' AND ID = ?';
+      params.push(roleId);
+    }
 
     return db.execute(query, params);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,10 @@ class AccountService extends Service {
   registerPublicEndpoints() {
     this.app.get(`${SVC_API}/health`, routes.healthCheck);
 
+    // User Role Routes
     this.app.post(`${SVC_API}/setup/role`, routes.settingRoutes.registerUserRole);
+    this.app.get(`${SVC_API}/setup/role`, routes.settingRoutes.getUserRole);
+    this.app.get(`${SVC_API}/setup/role/:roleId`, routes.settingRoutes.getUserRole);
   }
 
   registerPrivateEndpoints() {}

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -12,6 +12,16 @@ servers:
     description: Local development servers
 
 components:
+  parameters:
+    RoleIdParam:
+      name: roleId
+      description: The ID of role to verify
+      in: path
+      required: true
+      schema:
+        type: string
+        pattern: '^[A-F0-9]{8}:[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{11}'
+
   schemas:
     healthCheckData:
       title: Schema for Health Check Data
@@ -44,6 +54,31 @@ components:
       required:
         - role_code
         - role_desc
+
+    getUserRolesResponseData:
+      title: Schema for User Role Response Data
+      type: object
+      properties:
+        id:
+          type: string
+        role_code:
+          type: string
+        role_desc:
+          type: string
+        is_active:
+          type: boolean
+        is_default:
+          type: boolean
+        created_date:
+          type: string
+        modified_date:
+          type: string
+      required:
+        - id
+        - role_code
+        - role_desc
+        - is_active
+        - is_default
 
     healthCheckSuccessResponse:
       type: object
@@ -84,12 +119,67 @@ components:
         success:
           type: boolean
           example: true
+        data:
+          type: object
+          $ref: '#/components/schemas/getUserRolesResponseData'
       required:
         - status
         - type
         - message
         - devMessage
         - success
+        - data
+
+    getUserRolesResponse:
+      type: object
+      properties:
+        status:
+          type: integer
+          example: 201
+        type:
+          type: string
+          example: 'SUCCESS'
+        message:
+          type: string
+          example: 'Success'
+        devMessage:
+          type: string
+          example: 'Success'
+        success:
+          type: boolean
+          example: true
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/getUserRolesResponseData'
+      required:
+        - status
+        - type
+        - message
+        - devMessage
+        - success
+        - data
+
+    noContentResponse:
+      type: object
+      properties:
+        statusCode:
+          type: integer
+          example: 204
+        type:
+          type: string
+          example: 'CONTENT_NOT_AVAILABLE'
+        message:
+          type: string
+          example: 'No content available'
+        devMessage:
+          type: string
+          example: 'No content available'
+        success:
+          type: boolean
+          example: true
+        data:
+          type: array
 
     badRequestResponse:
       type: object
@@ -146,6 +236,26 @@ components:
         devMessage:
           type: string
           example: Forbidden access. Could not proceed with the request.
+        error:
+          type: array
+        data:
+          type: array
+
+    notFoundResponse:
+      type: object
+      properties:
+        statusCode:
+          type: integer
+          example: 404
+        type:
+          type: string
+          example: 'NOT_FOUND'
+        message:
+          type: string
+          example: 'Resource Not Found'
+        devMessage:
+          type: string
+          example: Not Found. Requested resource does not exist.
         error:
           type: array
         data:
@@ -253,6 +363,93 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/conflictResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/internalServerErrorResponse'
+
+    get:
+      operationId: GetUserRoles
+      summary: Get all User Roles
+      description: An API to fetch all user roles exist in system.
+      responses:
+        '200':
+          description: SUCCESS
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/getUserRolesResponse'
+        '204':
+          description: CONTENT_NOT_AVAILABLE
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/noContentResponse'
+        '400':
+          description: BAD_REQUEST
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/badRequestResponse'
+        '401':
+          description: UNAUTHORIZED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/unauthorizedResponse'
+        '403':
+          description: FORBIDDEN
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/forbiddenResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/internalServerErrorResponse'
+
+  /setup/role/{roleId}:
+    get:
+      operationId: getUserRoleInfoById
+      summary: Get User Role Info by ID
+      description: An API to retrieve the user role info for requested ID.
+      parameters:
+        - $ref: '#/components/parameters/RoleIdParam'
+      responses:
+        '200':
+          description: SUCCESS
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/registerUserRoleResponse'
+        '400':
+          description: BAD_REQUEST
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/badRequestResponse'
+        '401':
+          description: UNAUTHORIZED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/unauthorizedResponse'
+        '403':
+          description: FORBIDDEN
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/forbiddenResponse'
+        '404':
+          description: NOT_FOUND
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/notFoundResponse'
         '500':
           description: Internal Server Error
           content:

--- a/src/routes/system-setup-routes/getUserRole.route.js
+++ b/src/routes/system-setup-routes/getUserRole.route.js
@@ -1,0 +1,32 @@
+'use strict';
+
+import { _Error, logger, ResponseBuilder } from 'common-svc-lib';
+import controllers from '../../controllers/index.js';
+
+const log = logger('Router: get-user-role');
+const settingController = controllers.settingController;
+
+// API Function
+const getUserRole = async (req, res, next) => {
+  try {
+    log.info('Fetch user role request process initiated');
+    const roleId = req.params.roleId;
+    let roleDtl;
+
+    if (roleId) {
+      log.info('Call controller function to fetch the user role for requested id');
+      roleDtl = await settingController.getUserRoleById(roleId);
+    } else {
+      log.info('Call controller function to fetch all user roles from system');
+      roleDtl = await settingController.getAllUserRoles();
+    }
+
+    log.success('User roles fetched successfully');
+    res.status(200).json(ResponseBuilder(roleDtl));
+  } catch (err) {
+    log.error('Error occurred while processing the request');
+    next(_Error(500, 'An error occurred while processing the request', err));
+  }
+};
+
+export default getUserRole;

--- a/src/routes/system-setup-routes/index.js
+++ b/src/routes/system-setup-routes/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
 import registerUserRole from './registerUserRole.route.js';
+import getUserRole from './getUserRole.route.js';
 
 export default {
   registerUserRole,
+  getUserRole,
 };

--- a/src/routes/system-setup-routes/registerUserRole.route.js
+++ b/src/routes/system-setup-routes/registerUserRole.route.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { logger, ResponseBuilder } from 'common-svc-lib';
+import { logger, ResponseBuilder, _Error } from 'common-svc-lib';
 import controllers from '../../controllers/index.js';
 
 const log = logger('Router: create-user-role');
@@ -23,7 +23,7 @@ const registerUserRole = async (req, res, next) => {
     res.status(201).json(ResponseBuilder(roleDtl));
   } catch (err) {
     log.error('Error occurred while processing the request');
-    next(err);
+    next(_Error(500, 'An error occurred while processing the request', err));
   }
 };
 


### PR DESCRIPTION
## Summary
- Introduced a Get User Role API to retrieve:
  - All user roles, or
  - A specific user role by ID
- This API enables consumers to fetch role details in a consistent and standardized response format.
### API Endpoints
- Get all user roles
  GET /api/v1.0/setup/role
- Get user role by ID
  GET /api/v1.0/setup/role/:roleId
### Response Payload
The API returns user role record(s) with the following fields:
- id
- role_code
- role_desc
- is_active
- is_default
- modified_date
- created_date
### Behavior & Notes
- When roleId is provided, the API returns the corresponding user role record
- When roleId is not provided, the API returns all user roles from the database
- Ensures consistent response structure across both endpoints