### PR TITLE
Add API to create and register access scopes

### DIFF
--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -39,5 +39,16 @@
     "Requested user does not exists": "Requested user does not exists",
     "User Profile fetched successfully": "User Profile fetched successfully",
     "An error occurred while performing user logout operation": "An error occurred while performing user logout operation",
-    "User logout": "User logout"
+    "User logout": "User logout",
+    "Refresh Token not found": "Refresh Token not found",
+    "No Token stored in db": "No Token available",
+    "Invalid Token found": "Invalid Token found",
+    "Token Expired or Invalid": "Token Expired or Invalid",
+    "User scope already exists": "User scope already exists",
+    "User scope does not exists in system": "User scope does not exists in system",
+    "An error occurred while validating user scope in system": "Error occurred while validating user scope in system",
+    "User scope registered successfully": "User scope registered successfully",
+    "An error occurred while registering new user scope in system": "Error occurred while registering new user scope in system",
+    "User scope not found": "User scope not found",
+    "User scope found": "User scope found"
 }

--- a/src/controllers/account-controllers/getUserInfo.controller.js
+++ b/src/controllers/account-controllers/getUserInfo.controller.js
@@ -4,7 +4,7 @@ import { _Error, _Response, convertPrettyStringToId, formatResponseBody, logger 
 import { AccountDB } from '../../db/index.js';
 import { fieldMappings } from '../../utils/index.js';
 
-const log = logger('Controller: get-user-info');
+const log = logger('Controller: Get-User-Info');
 
 const getUserInfoById = async (userId) => {
   try {

--- a/src/controllers/account-controllers/logout.controller.js
+++ b/src/controllers/account-controllers/logout.controller.js
@@ -3,7 +3,7 @@
 import { _Error, _Response, convertPrettyStringToId, logger } from 'common-svc-lib';
 import { AccountDB } from '../../db/index.js';
 
-const log = logger('Controller: Logout-User');
+const log = logger('Controller: Logout');
 
 const logout = async (userId) => {
   try {

--- a/src/controllers/account-controllers/registerUser.controller.js
+++ b/src/controllers/account-controllers/registerUser.controller.js
@@ -7,7 +7,7 @@ import { SALT_ROUNDS } from '../../constants.js';
 import { getUserInfoById } from './getUserInfo.controller.js';
 import { generateEmailVerificationCode } from './verificationCode.controller.js';
 
-const log = logger('Controller: register-user');
+const log = logger('Controller: Register-User');
 
 const verifyUsernameEmailAlreadyTaken = async (payload) => {
   try {

--- a/src/controllers/account-controllers/verificationCode.controller.js
+++ b/src/controllers/account-controllers/verificationCode.controller.js
@@ -5,7 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { AccountDB } from '../../db/index.js';
 import { requestEmailSend } from '../../utils/index.js';
 
-const log = logger('Controller: verification-code');
+const log = logger('Controller: Verification-Code');
 
 const generateEmailVerificationCode = async (userId, userDtl, headers) => {
   try {

--- a/src/controllers/account-controllers/verifyUser.controller.js
+++ b/src/controllers/account-controllers/verifyUser.controller.js
@@ -5,7 +5,7 @@ import { AccountDB } from '../../db/index.js';
 import { generateEmailVerificationCode } from './verificationCode.controller.js';
 import { requestEmailSend } from '../../utils/index.js';
 
-const log = logger('Controller: verify-user');
+const log = logger('Controller: Verify-User');
 
 const sendVerificationConfirmationMail = (userId, userDtl, headers) => {
   const userPayload = {

--- a/src/controllers/system-setup-controllers/getUserRole.controller.js
+++ b/src/controllers/system-setup-controllers/getUserRole.controller.js
@@ -4,7 +4,7 @@ import { logger, convertPrettyStringToId, formatResponseBody, _Response, _Error 
 import { SystemDB } from '../../db/index.js';
 import { fieldMappings } from '../../utils/index.js';
 
-const log = logger('Controller: get-user-role-info');
+const log = logger('Controller: Get-Role-Info');
 
 const getUserRoleById = async (roleId) => {
   try {

--- a/src/controllers/system-setup-controllers/getUserScope.controller.js
+++ b/src/controllers/system-setup-controllers/getUserScope.controller.js
@@ -1,0 +1,32 @@
+'use strict';
+
+import { _Error, _Response, convertPrettyStringToId, formatResponseBody, logger } from 'common-svc-lib';
+import { SystemDB } from '../../db/index.js';
+import { fieldMappings } from '../../utils/index.js';
+
+const log = logger('Controller: Get-Scope-Info');
+
+const getUserScopeById = async (scopeId) => {
+  try {
+    log.info('Controller function to fetch the details of user scope by id process initiated');
+    scopeId = convertPrettyStringToId(scopeId);
+
+    log.info(`Call db query to fetch user scope details for provided id: ${scopeId}`);
+    let scopeDtl = await SystemDB.getUserScope(null, scopeId);
+    if (scopeDtl.rowCount === 0) {
+      log.error('User scope requested with the id does not exists in system');
+      throw _Error(404, 'User scope not found');
+    }
+
+    scopeDtl = scopeDtl.rows;
+    formatResponseBody(scopeDtl, fieldMappings.userScopeFields);
+    scopeDtl = scopeDtl[0];
+    log.success('Requested scope details fetched successfully');
+    return _Response(200, 'User scope found', scopeDtl);
+  } catch (err) {
+    log.error('Error occurred while trying to fetch the details of user scope for requested id');
+    throw _Error(500, 'An error occurred while fetching user scope details', err);
+  }
+};
+
+export { getUserScopeById };

--- a/src/controllers/system-setup-controllers/index.js
+++ b/src/controllers/system-setup-controllers/index.js
@@ -2,10 +2,15 @@
 
 import { verifyUserRoleExist, registerNewUserRole } from './registerUserRole.controller.js';
 import { getUserRoleById, getAllUserRoles } from './getUserRole.controller.js';
+import { verifyUserScopeExist, registerNewUserScope } from './registerUserScope.controller.js';
+import { getUserScopeById } from './getUserScope.controller.js';
 
 export default {
   verifyUserRoleExist,
   registerNewUserRole,
   getUserRoleById,
   getAllUserRoles,
+  verifyUserScopeExist,
+  registerNewUserScope,
+  getUserScopeById,
 };

--- a/src/controllers/system-setup-controllers/registerUserRole.controller.js
+++ b/src/controllers/system-setup-controllers/registerUserRole.controller.js
@@ -4,7 +4,7 @@ import { logger, _Error, _Response } from 'common-svc-lib';
 import { SystemDB } from '../../db/index.js';
 import { getUserRoleById } from './getUserRole.controller.js';
 
-const log = logger('Controller: register-user-role');
+const log = logger('Controller: Register-Role');
 
 const verifyUserRoleExist = async (roleCode) => {
   try {
@@ -12,7 +12,7 @@ const verifyUserRoleExist = async (roleCode) => {
     log.info('Call db query to validate if user role already exists');
     const roleDtl = await SystemDB.getUserRoleByCode(roleCode);
 
-    if (roleDtl.rows.length > 0) {
+    if (roleDtl.rowCount > 0) {
       log.error('User role already exists in system');
       throw _Error(409, 'User role already exists');
     }

--- a/src/controllers/system-setup-controllers/registerUserScope.controller.js
+++ b/src/controllers/system-setup-controllers/registerUserScope.controller.js
@@ -1,0 +1,44 @@
+'use strict';
+
+import { _Error, _Response, logger } from 'common-svc-lib';
+import { SystemDB } from '../../db/index.js';
+import { getUserScopeById } from './getUserScope.controller.js';
+
+const log = logger('Controller: Register-Scope');
+
+const verifyUserScopeExist = async (scopeCode) => {
+  try {
+    log.info('Controller function for validating user scope existence in system initiated');
+    log.info('Call db query to validate if user scope already exists');
+    const scopeDtl = await SystemDB.getUserScopeByCode(scopeCode);
+
+    if (scopeDtl.rowCount > 0) {
+      log.error('User scope already exists in system');
+      throw _Error(409, 'User scope already exists');
+    }
+
+    log.success('User scope verification completed successfully');
+    return _Response(200, 'User scope does not exists in system', []);
+  } catch (err) {
+    log.error('Error while validating new user scope in system');
+    throw _Error(500, 'An error occurred while validating user scope in system', err);
+  }
+};
+
+const registerNewUserScope = async (payload) => {
+  try {
+    log.info('Controller function to register new user scope process initiated');
+    log.info('Call db query to register new user scope in system');
+    const newScope = await SystemDB.registerNewScope(payload);
+    const newScopeId = newScope.rows[0].id;
+    const newScopeDtl = await getUserScopeById(newScopeId);
+
+    log.success('New user scope registered successfully in system');
+    return _Response(201, 'User scope registered successfully', newScopeDtl.data);
+  } catch (err) {
+    log.error('Error while registering new user scope in system');
+    throw _Error(500, 'An error occurred while registering new user scope in system', err);
+  }
+};
+
+export { verifyUserScopeExist, registerNewUserScope };

--- a/src/db/system.db.js
+++ b/src/db/system.db.js
@@ -73,7 +73,8 @@ class SystemDB extends DBQuery {
       params.push(roleId);
     }
     if (scopeId) {
-      query += ` FROM ${this.tables['USER_SCOPE']} S
+      query += `, S.CREATED_DATE, S.MODIFIED_DATE
+        FROM ${this.tables['USER_SCOPE']} S
         WHERE S.ID = ? AND S.IS_DELETED = false;`;
       params.push(scopeId);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,9 @@ class AccountService extends Service {
     this.app.post(`${SVC_API}/setup/role`, routes.settingRoutes.registerUserRole);
     this.app.get(`${SVC_API}/setup/role`, routes.settingRoutes.getUserRole);
     this.app.get(`${SVC_API}/setup/role/:roleId`, routes.settingRoutes.getUserRole);
+
+    // User Scope Routes
+    this.app.post(`${SVC_API}/setup/scope`, routes.settingRoutes.registerUserScope);
   }
 }
 

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1,14 +1,14 @@
 openapi: 3.0.0
 info:
-  title: Accounts Service
+  title: Identity Service
   version: 1.0.0
-  description: The Accounts Service is responsible for managing user-related operations and system configurations.
+  description: The Identity Service is responsible for managing user-related operations and system configurations.
     User Management - Create, retrieve, update and delete user accounts.
     Authentication & Authorization - Handle user authentication, session management, and access control.
     System Configurations - Manage system-specific setting such as API configurations, user scopes and groups.
 
 servers:
-  - url: /accounts-svc/api/v1.0
+  - url: /identity-svc/api/v1.0
     description: Local development servers
 
 components:
@@ -138,6 +138,21 @@ components:
       required:
         - role_code
         - role_desc
+
+    registerUserScopePayload:
+      type: object
+      properties:
+        scope_code:
+          type: string
+          description: Scope Code
+          minLength: 1
+        scope_desc:
+          type: string
+          description: Scope Description
+          minLength: 1
+      required:
+        - scope_code
+        - scope_desc
 
     getUserResponseData:
       title: Schema for User Response Data
@@ -270,6 +285,25 @@ components:
         - role_desc
         - is_active
         - is_default
+
+    getUserScopesResponseData:
+      title: Schema for User Scope Response Data
+      type: object
+      properties:
+        id:
+          type: string
+        scope_code:
+          type: string
+        scope_desc:
+          type: string
+        created_date:
+          type: string
+        modified_date:
+          type: string
+      required:
+        - id
+        - scope_code
+        - scope_desc
 
     healthCheckSuccessResponse:
       type: object
@@ -456,6 +490,35 @@ components:
         data:
           type: object
           $ref: '#/components/schemas/getUserRolesResponseData'
+      required:
+        - status
+        - type
+        - message
+        - devMessage
+        - success
+        - data
+
+    registerUserScopeResponse:
+      type: object
+      properties:
+        status:
+          type: integer
+          example: 201
+        type:
+          type: string
+          example: 'SUCCESS'
+        message:
+          type: string
+          example: 'Success'
+        devMessage:
+          type: string
+          example: 'Success'
+        success:
+          type: boolean
+          example: true
+        data:
+          type: object
+          $ref: '#/components/schemas/getUserScopesResponseData'
       required:
         - status
         - type
@@ -1079,6 +1142,55 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/notFoundResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/internalServerErrorResponse'
+
+  /setup/scope:
+    post:
+      operationId: registerUserScope
+      summary: Register User Scope
+      description: An API to register new user scope in the system.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/registerUserScopePayload'
+      responses:
+        '201':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/registerUserScopeResponse'
+        '400':
+          description: BAD_REQUEST
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/badRequestResponse'
+        '401':
+          description: UNAUTHORIZED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/unauthorizedResponse'
+        '403':
+          description: FORBIDDEN
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/forbiddenResponse'
+        '409':
+          description: CONFLICT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/conflictResponse'
         '500':
           description: Internal Server Error
           content:

--- a/src/routes/account-routes/login.route.js
+++ b/src/routes/account-routes/login.route.js
@@ -5,7 +5,7 @@ import controllers from '../../controllers/index.js';
 import { validateFields } from '../../utils/index.js';
 import { COOKIE_OPTIONS } from '../../constants.js';
 
-const log = logger('Router: login');
+const log = logger('Router: Login');
 const accountController = controllers.accountController;
 
 // API Function

--- a/src/routes/account-routes/logout.route.js
+++ b/src/routes/account-routes/logout.route.js
@@ -3,7 +3,7 @@
 import { logger, ResponseBuilder } from 'common-svc-lib';
 import controllers from '../../controllers/index.js';
 
-const log = logger('Router: Logout-User');
+const log = logger('Router: Logout');
 const accountController = controllers.accountController;
 
 // API Function

--- a/src/routes/account-routes/registerUser.route.js
+++ b/src/routes/account-routes/registerUser.route.js
@@ -4,7 +4,7 @@ import { _Error, logger, ResponseBuilder } from 'common-svc-lib';
 import controllers from '../../controllers/index.js';
 import { validateFields } from '../../utils/index.js';
 
-const log = logger('Router: register-user');
+const log = logger('Router: Register-User');
 const accountController = controllers.accountController;
 
 // API Function

--- a/src/routes/account-routes/userInfo.route.js
+++ b/src/routes/account-routes/userInfo.route.js
@@ -3,7 +3,7 @@
 import { _Error, logger, ResponseBuilder } from 'common-svc-lib';
 import controller from '../../controllers/index.js';
 
-const log = logger('Route: get-user-info');
+const log = logger('Route: Get-User-Info');
 const accountController = controller.accountController;
 
 // API Function

--- a/src/routes/account-routes/verifyUser.route.js
+++ b/src/routes/account-routes/verifyUser.route.js
@@ -3,7 +3,7 @@
 import { _Error, logger, ResponseBuilder } from 'common-svc-lib';
 import controllers from '../../controllers/index.js';
 
-const log = logger('Router: verify-user');
+const log = logger('Router: Verify-User');
 const accountController = controllers.accountController;
 
 // API Function

--- a/src/routes/system-setup-routes/getUserRole.route.js
+++ b/src/routes/system-setup-routes/getUserRole.route.js
@@ -3,7 +3,7 @@
 import { _Error, logger, ResponseBuilder } from 'common-svc-lib';
 import controllers from '../../controllers/index.js';
 
-const log = logger('Router: get-user-role');
+const log = logger('Router: Get-Role');
 const settingController = controllers.settingController;
 
 // API Function

--- a/src/routes/system-setup-routes/index.js
+++ b/src/routes/system-setup-routes/index.js
@@ -2,8 +2,10 @@
 
 import registerUserRole from './registerUserRole.route.js';
 import getUserRole from './getUserRole.route.js';
+import registerUserScope from './registerUserScope.route.js';
 
 export default {
   registerUserRole,
   getUserRole,
+  registerUserScope,
 };

--- a/src/routes/system-setup-routes/registerUserRole.route.js
+++ b/src/routes/system-setup-routes/registerUserRole.route.js
@@ -3,7 +3,7 @@
 import { logger, ResponseBuilder, _Error } from 'common-svc-lib';
 import controllers from '../../controllers/index.js';
 
-const log = logger('Router: create-user-role');
+const log = logger('Router: Register-Role');
 const settingController = controllers.settingController;
 
 // API Function

--- a/src/routes/system-setup-routes/registerUserScope.route.js
+++ b/src/routes/system-setup-routes/registerUserScope.route.js
@@ -1,0 +1,30 @@
+'use strict';
+
+import { logger, ResponseBuilder, _Error } from 'common-svc-lib';
+import controllers from '../../controllers/index.js';
+
+const log = logger('Router: Register-Scope');
+const settingController = controllers.settingController;
+
+// API Function
+const registerUserScope = async (req, res, next) => {
+  try {
+    log.info('Register user scope request process initiated');
+    const payload = req.body;
+    payload.scope_code = payload.scope_code.toUpperCase().trim();
+
+    log.info('Call controller function to validate if scope code valid to create or not');
+    await settingController.verifyUserScopeExist(payload.scope_code);
+
+    log.info('Call controller function to register new user scope in system');
+    const scopeDtl = await settingController.registerNewUserScope(payload);
+
+    log.success('User scope registered successfully');
+    res.status(201).json(ResponseBuilder(scopeDtl));
+  } catch (err) {
+    log.error('Error occurred while processing the request');
+    next(_Error(500, 'An error occurred while processing the request', err));
+  }
+};
+
+export default registerUserScope;

--- a/src/utils/fieldMappings/index.js
+++ b/src/utils/fieldMappings/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { userRoleMappingFields, userRoleFields } from './user-role-fields.js';
+import { userRoleMappingFields, userRoleFields, userScopeMappingFields, userScopeFields } from './user-role-fields.js';
 import { userMappingFields, userMetadataMappingField, userFields, userMetadataField } from './user-fields.js';
 
 export default {
@@ -10,4 +10,6 @@ export default {
   userMetadataMappingField,
   userFields,
   userMetadataField,
+  userScopeMappingFields,
+  userScopeFields,
 };

--- a/src/utils/fieldMappings/user-role-fields.js
+++ b/src/utils/fieldMappings/user-role-fields.js
@@ -18,4 +18,18 @@ const userRoleFields = {
   is_deleted: 'is_deleted',
 };
 
-export { userRoleMappingFields, userRoleFields };
+const userScopeMappingFields = {
+  scope_code: 'scope_cd',
+  scope_desc: 'scope_desc',
+};
+
+const userScopeFields = {
+  id: 'id',
+  scope_cd: 'scope_code',
+  scope_desc: 'scope_desc',
+  created_date: 'created_date',
+  modified_date: 'modified_date',
+  is_deleted: 'is_deleted',
+};
+
+export { userRoleMappingFields, userRoleFields, userScopeMappingFields, userScopeFields };


### PR DESCRIPTION
## Description
- This PR introduces a new setup API to register access scopes in the system. The API validates input, prevents duplicate scope creation, and returns the details of the newly created scope.
### API Endpoint
- Create Scope
  POST /api/v1.0/setup/scope
### Request Payload
| Field        | Description                     | Required |
| ------------ | ------------------------------- | -------- |
| `scope_code` | Unique identifier for the scope | Yes      |
| `scope_desc` | Description of the scope        | Yes      |
- Both fields must contain more than one character.
### Response Payload
On successful creation, the API returns:
- id – Newly created scope ID
- scope_code – Created scope code
- scope_desc – Created scope description
- created_date – Scope creation timestamp
- modified_date – Last modification timestamp
### API Flow & Logic
- Request Validation
  - Validates presence of scope_code and scope_desc.
  - Ensures both fields contain more than one character.
  - Returns 400 Bad Request for invalid input.
- Duplicate Scope Check
  - Verifies whether a scope with the same scope_code already exists.
  - Returns 409 Conflict if a duplicate scope is found.
- Scope Creation
  - Registers the new scope in the system.
  - Fetches the newly created scope details from the database.
- Response
  - Returns the created scope details to the client.
### Key Highlights
- Prevents duplicate scope creation
- Enforces strict input validation
- Returns complete scope metadata
- Designed for setup and administrative workflows