### PR TITLE
Add APIs to fetch scopes by ID or list all scopes

### DIFF
--- a/src/controllers/system-setup-controllers/getUserScope.controller.js
+++ b/src/controllers/system-setup-controllers/getUserScope.controller.js
@@ -29,4 +29,24 @@ const getUserScopeById = async (scopeId) => {
   }
 };
 
-export { getUserScopeById };
+const getAllUserScopes = async () => {
+  try {
+    log.info('Controller funciton to fetch all user scopes process initiated');
+    log.info('Call db query to fetch all user scopes');
+    let scopeDtl = await SystemDB.getUserScope();
+    if (scopeDtl.rowCount === 0) {
+      log.info('No user scope available to return');
+      return _Response(204, 'No user scope found', scopeDtl.rows);
+    }
+
+    scopeDtl = scopeDtl.rows;
+    formatResponseBody(scopeDtl, fieldMappings.userScopeFields);
+    log.success('User scopes fetched successfully');
+    return _Response(200, 'User scope found', scopeDtl);
+  } catch (err) {
+    log.error('Error occurred while trying to fetch all user scopes');
+    throw _Error(500, 'An error occurred while fetching user scopes', err);
+  }
+};
+
+export { getUserScopeById, getAllUserScopes };

--- a/src/controllers/system-setup-controllers/index.js
+++ b/src/controllers/system-setup-controllers/index.js
@@ -3,7 +3,7 @@
 import { verifyUserRoleExist, registerNewUserRole } from './registerUserRole.controller.js';
 import { getUserRoleById, getAllUserRoles } from './getUserRole.controller.js';
 import { verifyUserScopeExist, registerNewUserScope } from './registerUserScope.controller.js';
-import { getUserScopeById } from './getUserScope.controller.js';
+import { getUserScopeById, getAllUserScopes } from './getUserScope.controller.js';
 
 export default {
   verifyUserRoleExist,
@@ -13,4 +13,5 @@ export default {
   verifyUserScopeExist,
   registerNewUserScope,
   getUserScopeById,
+  getAllUserScopes,
 };

--- a/src/db/system.db.js
+++ b/src/db/system.db.js
@@ -78,6 +78,10 @@ class SystemDB extends DBQuery {
         WHERE S.ID = ? AND S.IS_DELETED = false;`;
       params.push(scopeId);
     }
+    if (!roleId && !scopeId) {
+      query += ` FROM ${this.tables['USER_SCOPE']} S
+        WHERE S.IS_DELETED = false;`;
+    }
 
     return await db.execute(query, params);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,8 @@ class AccountService extends Service {
 
     // User Scope Routes
     this.app.post(`${SVC_API}/setup/scope`, routes.settingRoutes.registerUserScope);
+    this.app.get(`${SVC_API}/setup/scope`, routes.settingRoutes.getUserScope);
+    this.app.get(`${SVC_API}/setup/scope/:scopeId`, routes.settingRoutes.getUserScope);
   }
 }
 

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -39,6 +39,15 @@ components:
       schema:
         type: string
 
+    ScopeIdParam:
+      name: scopeId
+      description: The ID of scope to verify
+      in: path
+      required: true
+      schema:
+        type: string
+        pattern: '^[A-F0-9]{8}:[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{11}'
+
   schemas:
     Username:
       type: string
@@ -498,6 +507,36 @@ components:
         - success
         - data
 
+    getUserRolesResponse:
+      type: object
+      properties:
+        status:
+          type: integer
+          example: 201
+        type:
+          type: string
+          example: 'SUCCESS'
+        message:
+          type: string
+          example: 'Success'
+        devMessage:
+          type: string
+          example: 'Success'
+        success:
+          type: boolean
+          example: true
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/getUserRolesResponseData'
+      required:
+        - status
+        - type
+        - message
+        - devMessage
+        - success
+        - data
+
     registerUserScopeResponse:
       type: object
       properties:
@@ -527,7 +566,7 @@ components:
         - success
         - data
 
-    getUserRolesResponse:
+    getUserScopeResponse:
       type: object
       properties:
         status:
@@ -548,7 +587,7 @@ components:
         data:
           type: array
           items:
-            $ref: '#/components/schemas/getUserRolesResponseData'
+            $ref: '#/components/schemas/getUserScopesResponseData'
       required:
         - status
         - type
@@ -1191,6 +1230,93 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/conflictResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/internalServerErrorResponse'
+
+    get:
+      operationId: GetUserScopes
+      summary: Get all User Scopes
+      description: An API to fetch all user scopes exist in system.
+      responses:
+        '200':
+          description: SUCCESS
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/getUserScopeResponse'
+        '204':
+          description: CONTENT_NOT_AVAILABLE
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/noContentResponse'
+        '400':
+          description: BAD_REQUEST
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/badRequestResponse'
+        '401':
+          description: UNAUTHORIZED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/unauthorizedResponse'
+        '403':
+          description: FORBIDDEN
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/forbiddenResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/internalServerErrorResponse'
+
+  /setup/scope/{scopeId}:
+    get:
+      operationId: getUserScopeById
+      summary: Get User Scope Info by ID
+      description: An API to retrieve the user scope info for requested ID.
+      parameters:
+        - $ref: '#/components/parameters/ScopeIdParam'
+      responses:
+        '200':
+          description: SUCCESS
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/registerUserScopeResponse'
+        '400':
+          description: BAD_REQUEST
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/badRequestResponse'
+        '401':
+          description: UNAUTHORIZED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/unauthorizedResponse'
+        '403':
+          description: FORBIDDEN
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/forbiddenResponse'
+        '404':
+          description: NOT_FOUND
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/notFoundResponse'
         '500':
           description: Internal Server Error
           content:

--- a/src/routes/system-setup-routes/getUserScope.route.js
+++ b/src/routes/system-setup-routes/getUserScope.route.js
@@ -1,0 +1,32 @@
+'use strict';
+
+import { _Error, logger, ResponseBuilder } from 'common-svc-lib';
+import controllers from '../../controllers/index.js';
+
+const log = logger('Route: Get-Scope');
+const settingController = controllers.settingController;
+
+// API Function
+const getUserScope = async (req, res, next) => {
+  try {
+    log.info('Fetch user scope request process initiated');
+    const scopeId = req.params.scopeId;
+    let scopeDtl;
+
+    if (scopeId) {
+      log.info('Call controller function to fetch user scope for requested id');
+      scopeDtl = await settingController.getUserScopeById(scopeId);
+    } else {
+      log.info('Call controller function to fetch all user scopes from system');
+      scopeDtl = await settingController.getAllUserScopes();
+    }
+
+    log.success('User scopes fetched successfully');
+    res.status(200).json(ResponseBuilder(scopeDtl));
+  } catch (err) {
+    log.error('Error occurred while processing the request');
+    next(_Error(500, 'An error occurred while processing the request', err));
+  }
+};
+
+export default getUserScope;

--- a/src/routes/system-setup-routes/index.js
+++ b/src/routes/system-setup-routes/index.js
@@ -3,9 +3,11 @@
 import registerUserRole from './registerUserRole.route.js';
 import getUserRole from './getUserRole.route.js';
 import registerUserScope from './registerUserScope.route.js';
+import getUserScope from './getUserScope.route.js';
 
 export default {
   registerUserRole,
   getUserRole,
   registerUserScope,
+  getUserScope,
 };


### PR DESCRIPTION
## Description
- This PR introduces APIs to retrieve access scope information, supporting both fetching a specific scope by ID and listing all scopes available in the system.
### API Endpoints
- Get All Scopes
  GET /api/v1.0/setup/scope
- Get Scope by ID
  GET /api/v1.0/setup/scope/:scopeId
### Request Parameters
| Parameter | Description                    | Required |
| --------- | ------------------------------ | -------- |
| `scopeId` | Unique identifier of the scope | No       |
- If scopeId is not provided, all scopes are returned.
### Response Payload
- Common Fields
  - id
  - scope_code
  - scope_desc
- Additional Fields (Single Scope Response Only)
  - created_date
  - modified_date
### API Flow & Logic
1. Fetch All Scopes
    - Triggered when no scopeId is provided.
    - Returns:
      - 200 OK with an array of scope objects if scopes exist.
      - 204 No Content if no scopes are available in the system.
2. Fetch Scope by ID
    - Triggered when scopeId is provided.
    - Validates whether the scope exists.
    - Returns:
      - 200 OK with scope details if found.
      - 404 Not Found if no scope exists for the given ID.
### Key Highlights
- Supports both bulk and single scope retrieval
- Clean separation of list vs detail responses
- Proper HTTP status code usage
- Optimized response payload based on request type