### PR TITLE
Add API to soft delete access scopes

### DIFF
--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -62,5 +62,7 @@
     "User role deleted successfully": "The user role has been deleted successfully.",
     "Default user role cannot be deleted": "The default user role cannot be deleted.",
     "User scope details updated successfully": "User scope have been updated successfully.",
-    "An error occurred while updating user scope in system": "An error occurred while updating the user scope"
+    "An error occurred while updating user scope in system": "An error occurred while updating the user scope",
+    "User scope deleted successfully": "User scope has been deleted successfully.",
+    "An error occurred while deleting requested user scope": "An error occurred while deleting the requested user scope."
 }

--- a/src/controllers/system-setup-controllers/deleteUserScope.controller.js
+++ b/src/controllers/system-setup-controllers/deleteUserScope.controller.js
@@ -1,0 +1,24 @@
+'use strict';
+
+import { _Error, convertPrettyStringToId, logger } from 'common-svc-lib';
+import { SystemDB } from '../../db/index.js';
+
+const log = logger('Controller: Delete-Scope');
+
+const deleteUserScope = async (scopeId) => {
+  try {
+    log.info('Controller function to delete user scope process initiated');
+    scopeId = convertPrettyStringToId(scopeId);
+
+    log.info('Call db query to delete requested user scope');
+    await SystemDB.deleteScope(scopeId);
+
+    log.success('Requested user scope deleted successfully');
+    return true;
+  } catch (err) {
+    log.error('Error while deleting user scope in system');
+    throw _Error(500, 'An error occurred while deleting requested user scope', err);
+  }
+};
+
+export { deleteUserScope };

--- a/src/controllers/system-setup-controllers/index.js
+++ b/src/controllers/system-setup-controllers/index.js
@@ -7,6 +7,7 @@ import { getUserScopeById, getAllUserScopes } from './getUserScope.controller.js
 import { updateUserRoleDtl, updateRoleDefault } from './updateUserRole.controller.js';
 import { deleteUserRole } from './deleteUserRole.controller.js';
 import { updateUserScope } from './updateUserScope.controller.js';
+import { deleteUserScope } from './deleteUserScope.controller.js';
 
 export default {
   verifyUserRoleExist,
@@ -21,4 +22,5 @@ export default {
   updateRoleDefault,
   deleteUserRole,
   updateUserScope,
+  deleteUserScope,
 };

--- a/src/db/system.db.js
+++ b/src/db/system.db.js
@@ -151,6 +151,18 @@ class SystemDB extends DBQuery {
     const params = [payload.scope_desc, scopeId];
     return await db.execute(query, params);
   }
+
+  async deleteScope(scopeId) {
+    const updateCond = { IS_DELETED: true };
+    const whereCond = {
+      ID: '?',
+      IS_DELETED: false,
+    };
+
+    const query = this.updateQuery('USER_SCOPE', fieldMappings.userScopeMappingFields, updateCond, whereCond);
+    const params = [scopeId];
+    return await db.execute(query, params);
+  }
 }
 
 export default new SystemDB();

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ class AccountService extends Service {
     this.app.get(`${SVC_API}/setup/scope`, routes.settingRoutes.getUserScope);
     this.app.get(`${SVC_API}/setup/scope/:scopeId`, routes.settingRoutes.getUserScope);
     this.app.put(`${SVC_API}/setup/scope/:scopeId`, routes.settingRoutes.updateUserScope);
+    this.app.delete(`${SVC_API}/setup/scope/:scopeId`, routes.settingRoutes.deleteUserScope);
   }
 }
 

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1497,3 +1497,47 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/internalServerErrorResponse'
+
+    delete:
+      operationId: deleteUserScope
+      summary: Delete User Scope
+      description: An API to delete user scope in the system
+      parameters:
+        - $ref: '#/components/parameters/ScopeIdParam'
+      responses:
+        '200':
+          description: SUCCESS
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/registerUserScopeResponse'
+        '400':
+          description: BAD_REQUEST
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/badRequestResponse'
+        '401':
+          description: UNAUTHORIZED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/unauthorizedResponse'
+        '403':
+          description: FORBIDDEN
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/forbiddenResponse'
+        '404':
+          description: NOT_FOUND
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/notFoundResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/internalServerErrorResponse'

--- a/src/routes/system-setup-routes/deleteUserScope.route.js
+++ b/src/routes/system-setup-routes/deleteUserScope.route.js
@@ -1,0 +1,30 @@
+'use strict';
+
+import { _Error, logger, ResponseBuilder } from 'common-svc-lib';
+import controllers from '../../controllers/index.js';
+
+const log = logger('Router: Delete-Scope');
+const settingController = controllers.settingController;
+
+// API Function
+const deleteUserScope = async (req, res, next) => {
+  try {
+    log.info('Delete user scope request process initiated');
+    const scopeId = req.params.scopeId;
+
+    log.info('Call controller function to validate if scope with provided id exist');
+    const scopeDtl = await settingController.getUserScopeById(scopeId);
+
+    log.info('Call controller function to delete user scope for provided id');
+    await settingController.deleteUserScope(scopeId);
+
+    log.success('User scope deleted successfully');
+    scopeDtl.message = 'User scope deleted successfully';
+    res.status(200).json(ResponseBuilder(scopeDtl));
+  } catch (err) {
+    log.error('Error occurred while processing the request');
+    next(_Error(500, 'An error occurred while processing the request', err));
+  }
+};
+
+export default deleteUserScope;

--- a/src/routes/system-setup-routes/index.js
+++ b/src/routes/system-setup-routes/index.js
@@ -7,6 +7,7 @@ import getUserScope from './getUserScope.route.js';
 import updateUserRole from './updateUserRole.route.js';
 import deleteUserRole from './deleteUserRole.route.js';
 import updateUserScope from './updateUserScope.route.js';
+import deleteUserScope from './deleteUserScope.route.js';
 
 export default {
   registerUserRole,
@@ -16,4 +17,5 @@ export default {
   updateUserRole,
   deleteUserRole,
   updateUserScope,
+  deleteUserScope,
 };


### PR DESCRIPTION
## Description
- This PR introduces an API to soft delete access scopes, allowing scopes to be safely removed from active use while preserving historical data for auditing purposes.
### API Endpoint
- Delete Scope (Soft Delete)
  DELETE /api/v1.0/setup/scope/:scopeId
### Request Parameters
| Parameter | Description                    | Required |
| --------- | ------------------------------ | -------- |
| `scopeId` | Unique identifier of the scope | Yes      |
### Response Payload
On successful deletion, the API returns the scope details:
- id
- scope_code
- scope_desc
- created_date
- modified_date
### API Flow & Logic
- Scope Existence Validation
  - Validates whether a scope exists for the provided scopeId.
  - Returns 404 Not Found if no scope is found.
- Soft Delete Operation
  - Marks the scope as deleted by setting is_deleted = true.
  - Ensures the scope is no longer available for assignment or authorization.
- Response
  - Returns the soft-deleted scope details to the client.
### Key Highlights
- Implements non-destructive deletion via soft delete
- Preserves scope history for auditing and traceability
- Consistent error handling and status codes
- Designed for administrative setup workflows