### PR TITLE
Add API to fetch assigned and unassigned scopes for a role

### DIFF
--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -64,5 +64,10 @@
     "User scope details updated successfully": "User scope have been updated successfully.",
     "An error occurred while updating user scope in system": "An error occurred while updating the user scope",
     "User scope deleted successfully": "User scope has been deleted successfully.",
-    "An error occurred while deleting requested user scope": "An error occurred while deleting the requested user scope."
+    "An error occurred while deleting requested user scope": "An error occurred while deleting the requested user scope.",
+    "Assigned Scopes list fetched successfully": "Assigned scopes were retrieved successfully.",
+    "An error occurred while fetching assigned scopes to the requested role": "An error occurred while retrieving the assigned scopes for the requested role.",
+    "Unassigned Scopes list fetched successfully": "Unassigned scopes were retrieved successfully.",
+    "An error occurred while fetching unassigned scopes to the requested role": "An error occurred while retrieving the unassigned scopes for the requested role.",
+    "Incorrect operation type requested": "The requested operation type is invalid."
 }

--- a/src/controllers/system-setup-controllers/getScopeList.controller.js
+++ b/src/controllers/system-setup-controllers/getScopeList.controller.js
@@ -1,0 +1,55 @@
+'use strict';
+
+import { _Error, _Response, convertPrettyStringToId, formatResponseBody, logger } from 'common-svc-lib';
+import { SystemDB } from '../../db/index.js';
+import { fieldMappings } from '../../utils/index.js';
+
+const log = logger('Controller: Get-Scope-List');
+
+const getAssignedScopesList = async (roleId, roleDtl) => {
+  try {
+    log.info('Controller function to fetch the assigned scopes to the requested role process initiated');
+    roleId = convertPrettyStringToId(roleId);
+
+    log.info('Call db query to fetch assigned scopes list');
+    let scopeDtl = await SystemDB.getAssignedScopes(roleId);
+    if (scopeDtl.rowCount > 0) {
+      scopeDtl = scopeDtl.rows;
+      formatResponseBody(scopeDtl, fieldMappings.userScopeFields);
+      roleDtl.scopes = scopeDtl;
+    } else {
+      roleDtl.scopes = [];
+    }
+
+    log.success('Requested assigned scopes list to the provided role fetched successfully');
+    return _Response(200, 'Assigned Scopes list fetched successfully', roleDtl);
+  } catch (err) {
+    log.info('Error occurred while fetching assigned scopes to the requested role');
+    throw _Error(500, 'An error occurred while fetching assigned scopes to the requested role', err);
+  }
+};
+
+const getUnassignedScopesList = async (roleId, roleDtl) => {
+  try {
+    log.info('Controller function to fetch the unassigned scopes to the requested role process initiated');
+    roleId = convertPrettyStringToId(roleId);
+
+    log.info('Call db query to fetch unassigned scopes list');
+    let scopeDtl = await SystemDB.getUnassignedScopes(roleId);
+    if (scopeDtl.rowCount > 0) {
+      scopeDtl = scopeDtl.rows;
+      formatResponseBody(scopeDtl, fieldMappings.userScopeFields);
+      roleDtl.scopes = scopeDtl;
+    } else {
+      roleDtl.scopes = [];
+    }
+
+    log.success('Requested unassigned scopes list to the provided role fetched successfully');
+    return _Response(200, 'Unassigned Scopes list fetched successfully', roleDtl);
+  } catch (err) {
+    log.info('Error occurred while fetching unassigned scopes to the requested role');
+    throw _Error(500, 'An error occurred while fetching unassigned scopes to the requested role', err);
+  }
+};
+
+export { getAssignedScopesList, getUnassignedScopesList };

--- a/src/controllers/system-setup-controllers/index.js
+++ b/src/controllers/system-setup-controllers/index.js
@@ -8,6 +8,7 @@ import { updateUserRoleDtl, updateRoleDefault } from './updateUserRole.controlle
 import { deleteUserRole } from './deleteUserRole.controller.js';
 import { updateUserScope } from './updateUserScope.controller.js';
 import { deleteUserScope } from './deleteUserScope.controller.js';
+import { getAssignedScopesList, getUnassignedScopesList } from './getScopeList.controller.js';
 
 export default {
   verifyUserRoleExist,
@@ -23,4 +24,6 @@ export default {
   deleteUserRole,
   updateUserScope,
   deleteUserScope,
+  getAssignedScopesList,
+  getUnassignedScopesList,
 };

--- a/src/db/system.db.js
+++ b/src/db/system.db.js
@@ -163,6 +163,28 @@ class SystemDB extends DBQuery {
     const params = [scopeId];
     return await db.execute(query, params);
   }
+
+  async getAssignedScopes(roleId) {
+    const query = `SELECT S.ID, S.SCOPE_CD, S.SCOPE_DESC
+      FROM ${this.tables['ROLE_SCOPE']} R
+      INNER JOIN ${this.tables['USER_SCOPE']} S ON S.ID = R.SCOPE_ID AND S.IS_DELETED = false
+      WHERE R.ROLE_ID = ? AND R.IS_DELETED = false;`;
+    const params = [roleId];
+
+    return await db.execute(query, params);
+  }
+
+  async getUnassignedScopes(roleId) {
+    const query = `SELECT ID, SCOPE_CD, SCOPE_DESC
+      FROM ${this.tables['USER_SCOPE']}
+      WHERE ID NOT IN (SELECT SCOPE_ID
+        FROM ${this.tables['ROLE_SCOPE']}
+        WHERE ROLE_ID = ? AND IS_DELETED = false
+      );`;
+    const params = [roleId];
+
+    return await db.execute(query, params);
+  }
 }
 
 export default new SystemDB();

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ class AccountService extends Service {
     this.app.get(`${SVC_API}/setup/scope/:scopeId`, routes.settingRoutes.getUserScope);
     this.app.put(`${SVC_API}/setup/scope/:scopeId`, routes.settingRoutes.updateUserScope);
     this.app.delete(`${SVC_API}/setup/scope/:scopeId`, routes.settingRoutes.deleteUserScope);
+    this.app.get(`${SVC_API}/setup/role/:roleId/scopes`, routes.settingRoutes.getScopeList);
   }
 }
 

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -338,6 +338,36 @@ components:
         - scope_code
         - scope_desc
 
+    getUserScopeForRoleResponseData:
+      title: Schema for User Scopes for Role Response Data
+      type: object
+      properties:
+        id:
+          type: string
+        role_code:
+          type: string
+        role_desc:
+          type: string
+        is_active:
+          type: boolean
+        is_default:
+          type: boolean
+        created_date:
+          type: string
+        modified_date:
+          type: string
+        scopes:
+          type: array
+          items:
+            $ref: '#/components/schemas/getUserScopesResponseData'
+      required:
+        - id
+        - role_code
+        - role_desc
+        - is_active
+        - is_default
+        - scopes
+
     healthCheckSuccessResponse:
       type: object
       properties:
@@ -612,6 +642,36 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/getUserScopesResponseData'
+      required:
+        - status
+        - type
+        - message
+        - devMessage
+        - success
+        - data
+
+    fetchUserScopeForRoleResponse:
+      type: object
+      properties:
+        status:
+          type: integer
+          example: 200
+        type:
+          type: string
+          example: 'SUCCESS'
+        message:
+          type: string
+          example: 'Success'
+        devMessage:
+          type: string
+          example: 'Success'
+        success:
+          type: boolean
+          example: true
+        data:
+          type: object
+          items:
+            $ref: '#/components/schemas/getUserScopeForRoleResponseData'
       required:
         - status
         - type
@@ -1511,6 +1571,57 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/registerUserScopeResponse'
+        '400':
+          description: BAD_REQUEST
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/badRequestResponse'
+        '401':
+          description: UNAUTHORIZED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/unauthorizedResponse'
+        '403':
+          description: FORBIDDEN
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/forbiddenResponse'
+        '404':
+          description: NOT_FOUND
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/notFoundResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/internalServerErrorResponse'
+
+  /setup/role/{roleId}/scopes:
+    get:
+      operationId: getScopesListForRole
+      summary: Get Scopes List for Role
+      description: An API to get scopes list for specific role in the system.
+      parameters:
+        - $ref: '#/components/parameters/RoleIdParam'
+        - in: query
+          name: type
+          schema:
+            type: string
+          required: false
+          description: Assigned/Unassigned type for the user role
+      responses:
+        '200':
+          description: SUCCESS
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/fetchUserScopeForRoleResponse'
         '400':
           description: BAD_REQUEST
           content:

--- a/src/routes/system-setup-routes/getScopeList.route.js
+++ b/src/routes/system-setup-routes/getScopeList.route.js
@@ -1,0 +1,39 @@
+'use strict';
+
+import { _Error, logger, ResponseBuilder } from 'common-svc-lib';
+import controllers from '../../controllers/index.js';
+
+const log = logger('Router: Get-Scope-List');
+const settingController = controllers.settingController;
+
+// API Function
+const getScopeList = async (req, res, next) => {
+  try {
+    log.info('Fetch scopes list for requested role process initiated');
+    const roleId = req.params.roleId;
+    const operationType = req.query.type;
+
+    log.info('Call controller function to validate if user role for requested id exists');
+    const roleDtl = await settingController.getUserRoleById(roleId);
+
+    let roleScopeDtl;
+    if (operationType === 'assigned') {
+      log.info('Call controller function to fetch assigned scopes list for the requested role');
+      roleScopeDtl = await settingController.getAssignedScopesList(roleId, roleDtl.data);
+    } else if (operationType === 'unassigned') {
+      log.info('Call controller function to fetch unassigned scopes list for the requested role');
+      roleScopeDtl = await settingController.getUnassignedScopesList(roleId, roleDtl.data);
+    } else {
+      log.error(`Incorrect operation type [${operationType}] requested.`);
+      throw _Error(400, 'Incorrect operation type requested');
+    }
+
+    log.success('Requested scopes and role details fetched successfully');
+    res.status(200).json(ResponseBuilder(roleScopeDtl));
+  } catch (err) {
+    log.error('Error occurred while processing the request');
+    next(_Error(500, 'An error occurred while processing the request', err));
+  }
+};
+
+export default getScopeList;

--- a/src/routes/system-setup-routes/index.js
+++ b/src/routes/system-setup-routes/index.js
@@ -8,6 +8,7 @@ import updateUserRole from './updateUserRole.route.js';
 import deleteUserRole from './deleteUserRole.route.js';
 import updateUserScope from './updateUserScope.route.js';
 import deleteUserScope from './deleteUserScope.route.js';
+import getScopeList from './getScopeList.route.js';
 
 export default {
   registerUserRole,
@@ -18,4 +19,5 @@ export default {
   deleteUserRole,
   updateUserScope,
   deleteUserScope,
+  getScopeList,
 };


### PR DESCRIPTION
## Description
- This PR introduces an API to retrieve assigned or unassigned scopes for a given role, enabling effective role–scope management in RBAC workflows.
### API Endpoint
- Get Role Scopes
  GET /api/v1.0/setup/role/:roleId/scopes?type=assigned|unassigned
### Request Parameters
| Parameter | Description                   | Required |
| --------- | ----------------------------- | -------- |
| `roleId`  | Unique identifier of the role | Yes      |
### Query Parameters
| Parameter | Description                                 | Required |
| --------- | ------------------------------------------- | -------- |
| `type`    | Scope list type: `assigned` or `unassigned` | Yes      |
### Response Payload
The API returns role details along with the requested scope list:
- id
- role_code
- role_desc
- is_active
- is_default
- created_date
- modified_date
- scopes (array)
  - id
  - scope_code
  - scope_desc
### API Flow & Logic
1. Role Validation
    - Verifies whether a role exists for the provided roleId.
    - Returns 404 Not Found if the role does not exist.
2. Query Validation
    - Validates the type query parameter.
    - Allowed values:
      - assigned
      - unassigned
    - Returns 400 Bad Request for invalid values.
3. Scope Resolution
    - If type=assigned:
      - Fetches and returns scopes currently assigned to the role.
    - If type=unassigned:
      - Fetches and returns scopes not yet assigned to the role.
4. Response
    - Returns role details along with the requested scope list.
### Key Highlights
- Supports both assigned and unassigned scope retrieval
- Enables efficient role–scope mapping management
- Strong input validation and error handling
- Designed for RBAC setup and administration workflows