### PR TITLE
Add forgot password API and update verify email endpoint

### DIFF
--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -69,5 +69,9 @@
     "An error occurred while fetching assigned scopes to the requested role": "An error occurred while retrieving the assigned scopes for the requested role.",
     "Unassigned Scopes list fetched successfully": "Unassigned scopes were retrieved successfully.",
     "An error occurred while fetching unassigned scopes to the requested role": "An error occurred while retrieving the unassigned scopes for the requested role.",
-    "Incorrect operation type requested": "The requested operation type is invalid."
+    "Incorrect operation type requested": "The requested operation type is invalid.",
+    "One of the scope id provided is incorrect": "One of the scope id provided is incorrect",
+    "Scope assignment has been updated successfull": "Scope assignment has been updated successfull",
+    "An error occurred while updating the scope assignment to the requested role": "An error occurred while updating the scope assignment to the requested role",
+    "Email has been sent to the registered email id": "Email has been sent to the registered email id"
 }

--- a/src/controllers/account-controllers/forgotPassword.controller.js
+++ b/src/controllers/account-controllers/forgotPassword.controller.js
@@ -1,0 +1,31 @@
+'use strict';
+
+import { _Error, logger } from 'common-svc-lib';
+import { AccountDB } from '../../db/index.js';
+import { getUserInfoById } from './getUserInfo.controller.js';
+import { generatePasswordVerificationCode } from './verificationCode.controller.js';
+
+const log = logger('Controller: Forgot-Password');
+
+const forgotPasswordRequest = async (userIdentifier, headers) => {
+  try {
+    log.info('Controller function to generate password reset token process initiated');
+    const data = await AccountDB.isUsernameEmailInUse(userIdentifier, userIdentifier);
+    if (data.rowCount === 0) {
+      log.error('No user for the provided identifier found');
+    }
+    const userId = data.rows[0].id;
+
+    log.info('Fetch user details by user id');
+    let userDtl = await getUserInfoById(userId);
+    userDtl = userDtl.data;
+    await generatePasswordVerificationCode(userId, userDtl, headers);
+
+    log.success('User password reset token sent successfully');
+    return true;
+  } catch (err) {
+    log.error('Error occurred while generating the password reset token for the user');
+  }
+};
+
+export { forgotPasswordRequest };

--- a/src/controllers/account-controllers/index.js
+++ b/src/controllers/account-controllers/index.js
@@ -6,6 +6,7 @@ import { verifyUserToken } from './verifyUser.controller.js';
 import { loginUserVerification, grantUserAccess } from './login.controller.js';
 import { logout } from './logout.controller.js';
 import { isTokenAvailable } from './refreshToken.controller.js';
+import { forgotPasswordRequest } from './forgotPassword.controller.js';
 
 export default {
   verifyUsernameEmailAlreadyTaken,
@@ -18,4 +19,5 @@ export default {
   logout,
   isTokenAvailable,
   grantUserAccess,
+  forgotPasswordRequest,
 };

--- a/src/db/account.db.js
+++ b/src/db/account.db.js
@@ -140,6 +140,15 @@ class AccountDB extends DBQuery {
 
     return await db.execute(query, params);
   }
+
+  async registerPasswordVerification(userId, verificationCode, verificationCodeExpiry) {
+    const updateColumns = ['FORGOT_PASSWORD_TOKEN', 'FORGOT_PASSWORD_TOKEN_EXP'];
+    const whereColumns = ['USER_ID', 'IS_DELETED'];
+    const query = this.updateQuery('USER_METADATA', fieldMappings.userMetadataMappingField, updateColumns, whereColumns);
+    const params = [verificationCode, verificationCodeExpiry, userId, false];
+
+    return await db.execute(query, params);
+  }
 }
 
 export default new AccountDB();

--- a/src/db/system.db.js
+++ b/src/db/system.db.js
@@ -102,18 +102,18 @@ class SystemDB extends DBQuery {
   }
 
   async updateRoleDtl(roleId, payload = null, isDefault = null) {
-    let updateCond;
-    const whereCond = {
+    let updateColumns;
+    const whereColumns = {
       ID: '?',
       IS_DELETED: false,
     };
     let params;
 
     if (isDefault) {
-      updateCond = { IS_DEFAULT: isDefault };
+      updateColumns = { IS_DEFAULT: isDefault };
       params = [roleId];
     } else {
-      updateCond = {
+      updateColumns = {
         ROLE_DESC: '?',
         IS_ACTIVE: payload.is_active,
         IS_DEFAULT: payload.is_default,
@@ -121,45 +121,45 @@ class SystemDB extends DBQuery {
       params = [payload.role_desc, roleId];
     }
 
-    const query = this.updateQuery('USER_ROLE', fieldMappings.userRoleMappingFields, updateCond, whereCond);
+    const query = this.updateQuery('USER_ROLE', fieldMappings.userRoleMappingFields, updateColumns, whereColumns);
 
     return await db.execute(query, params);
   }
 
   async deleteRole(roleId) {
-    const updateCond = { IS_DELETED: true };
-    const whereCond = {
+    const updateColumns = { IS_DELETED: true };
+    const whereColumns = {
       ID: '?',
       IS_DELETED: false,
     };
 
-    const query = this.updateQuery('USER_ROLE', fieldMappings.userRoleMappingFields, updateCond, whereCond);
+    const query = this.updateQuery('USER_ROLE', fieldMappings.userRoleMappingFields, updateColumns, whereColumns);
     const params = [roleId];
     return await db.execute(query, params);
   }
 
   async updateScopeDtl(scopeId, payload) {
-    const updateCond = {
+    const updateColumns = {
       SCOPE_DESC: '?',
     };
-    const whereCond = {
+    const whereColumns = {
       ID: '?',
       IS_DELETED: false,
     };
 
-    const query = this.updateQuery('USER_SCOPE', fieldMappings.userScopeMappingFields, updateCond, whereCond);
+    const query = this.updateQuery('USER_SCOPE', fieldMappings.userScopeMappingFields, updateColumns, whereColumns);
     const params = [payload.scope_desc, scopeId];
     return await db.execute(query, params);
   }
 
   async deleteScope(scopeId) {
-    const updateCond = { IS_DELETED: true };
-    const whereCond = {
+    const updateColumns = { IS_DELETED: true };
+    const whereColumns = {
       ID: '?',
       IS_DELETED: false,
     };
 
-    const query = this.updateQuery('USER_SCOPE', fieldMappings.userScopeMappingFields, updateCond, whereCond);
+    const query = this.updateQuery('USER_SCOPE', fieldMappings.userScopeMappingFields, updateColumns, whereColumns);
     const params = [scopeId];
     return await db.execute(query, params);
   }
@@ -202,15 +202,15 @@ class SystemDB extends DBQuery {
   }
 
   async unassignScopesToRole(roleId, idsPlaceholder, scopeIdArr) {
-    const updateCond = {
+    const updateColumns = {
       IS_DELETED: true,
     };
-    const whereCond = {
+    const whereColumns = {
       IS_DELETED: false,
       ROLE_ID: '?',
     };
 
-    let query = this.updateQuery('ROLE_SCOPE', fieldMappings.userRoleMappingFields, updateCond, whereCond);
+    let query = this.updateQuery('ROLE_SCOPE', fieldMappings.userRoleMappingFields, updateColumns, whereColumns);
     query += ` AND SCOPE_ID IN (${idsPlaceholder})`;
 
     const params = [roleId, ...scopeIdArr];

--- a/src/index.js
+++ b/src/index.js
@@ -8,9 +8,10 @@ class AccountService extends Service {
   registerPublicEndpoints() {
     this.app.get(`${SVC_API}/health`, routes.healthCheck);
     this.app.post(`${SVC_API}/auth/register`, routes.accountRoutes.registerUser);
-    this.app.put(`${SVC_API}/auth/verify-email/:userId/:token`, routes.accountRoutes.verifyUser);
+    this.app.post(`${SVC_API}/auth/verify/email`, routes.accountRoutes.verifyUser);
     this.app.post(`${SVC_API}/auth/login`, routes.accountRoutes.loginUser);
-    this.app.post(`${SVC_API}/auth/refresh`, routes.accountRoutes.refreshToken);
+    this.app.post(`${SVC_API}/auth/token/refresh`, routes.accountRoutes.refreshToken);
+    this.app.post(`${SVC_API}/auth/password/forgot`, routes.accountRoutes.forgotPassword);
   }
 
   registerPrivateEndpoints() {

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -103,6 +103,19 @@ components:
         - email_id
         - password
 
+    verifyEmailPayload:
+      type: object
+      properties:
+        userId:
+          type: string
+          description: User Id
+        token:
+          type: string
+          description: Token
+      required:
+        - userId
+        - token
+
     loginUserPayload:
       type: object
       properties:
@@ -126,6 +139,16 @@ components:
           description: Refresh Token
       required:
         - refreshToken
+
+    forgotPasswordPayload:
+      type: object
+      properties:
+        userIdentifier:
+          type: string
+          description: Username or Email Id
+          minLength: 1
+      required:
+        - userIdentifier
 
     registerUserRolePayload:
       type: object
@@ -541,6 +564,31 @@ components:
         - success
         - data
 
+    forgotPasswordRequestResponse:
+      type: object
+      properties:
+        status:
+          type: integer
+          example: 200
+        type:
+          type: string
+          example: 'SUCCESS'
+        message:
+          type: string
+          example: 'Success'
+        devMessage:
+          type: string
+          example: 'Success'
+        success:
+          type: boolean
+          example: true
+      required:
+        - status
+        - type
+        - message
+        - devMessage
+        - success
+
     registerUserRoleResponse:
       type: object
       properties:
@@ -933,14 +981,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/internalServerErrorResponse'
 
-  /auth/verify-email/{userId}/{token}:
-    put:
+  /auth/verify/email:
+    post:
       operationId: verifyUser
       summary: Verify User Email ID
       description: An API to verify user email id in the system.
-      parameters:
-        - $ref: '#/components/parameters/UserIdParam'
-        - $ref: '#/components/parameters/TokenParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/verifyEmailPayload'
       responses:
         '200':
           description: SUCCESS
@@ -1108,7 +1159,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/internalServerErrorResponse'
 
-  /auth/refresh:
+  /auth/token/refresh:
     post:
       operationId: refreshUserToken
       summary: Refresh User Token
@@ -1138,6 +1189,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/notFoundResponse'
+        '500':
+          description: INTERNAL_SERVER_ERROR
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/internalServerErrorResponse'
+
+  /auth/password/forgot:
+    post:
+      operationId: forgotUserPassword
+      summary: Forgot User Password
+      description: An API to generate token for user forgot password request.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/forgotPasswordPayload'
+      responses:
+        '200':
+          description: SUCCESS
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/forgotPasswordRequestResponse'
+        '400':
+          description: BAD_REQUEST
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/badRequestResponse'
         '500':
           description: INTERNAL_SERVER_ERROR
           content:

--- a/src/routes/account-routes/forgotPassword.route.js
+++ b/src/routes/account-routes/forgotPassword.route.js
@@ -1,0 +1,38 @@
+'use strict';
+
+import { _Error, _Response, logger, ResponseBuilder } from 'common-svc-lib';
+import controllers from '../../controllers/index.js';
+import { validateFields } from '../../utils/index.js';
+
+const log = logger('Router: Forgot-Password');
+const accountController = controllers.accountController;
+
+// API Function
+const forgotPassword = async (req, res, next) => {
+  try {
+    log.info('Forgot password operation initiated');
+    const userIdentifier = req.body.userIdentifier;
+
+    let validationResult = true;
+    if (userIdentifier.includes('@')) {
+      validationResult = validateFields({ email_id: userIdentifier }, ['email_id']);
+    } else {
+      validationResult = validateFields({ username: userIdentifier }, ['username']);
+    }
+    if (validationResult !== true) {
+      log.error('Invalid user identifier provided');
+      throw _Error(400, validationResult);
+    }
+
+    log.info('Call controller function to send forgot password link to user if valid');
+    accountController.forgotPasswordRequest(userIdentifier, req.headers);
+
+    log.success('Forgot password operation completed successfully');
+    res.status(200).json(ResponseBuilder({ status: 200, message: 'Email has been sent to the registered email id', data: {} }));
+  } catch (err) {
+    log.error('Error occurred while processing the request');
+    next(_Error(500, 'An error occurred while processing the request', err));
+  }
+};
+
+export default forgotPassword;

--- a/src/routes/account-routes/index.js
+++ b/src/routes/account-routes/index.js
@@ -6,6 +6,7 @@ import loginUser from './login.route.js';
 import userInfo from './userInfo.route.js';
 import logoutUser from './logout.route.js';
 import refreshToken from './refresh.route.js';
+import forgotPassword from './forgotPassword.route.js';
 
 export default {
   registerUser,
@@ -14,4 +15,5 @@ export default {
   userInfo,
   logoutUser,
   refreshToken,
+  forgotPassword,
 };

--- a/src/routes/account-routes/verifyUser.route.js
+++ b/src/routes/account-routes/verifyUser.route.js
@@ -10,8 +10,8 @@ const accountController = controllers.accountController;
 const verifyUser = async (req, res, next) => {
   try {
     log.info('Verify user email id operation initiated');
-    const userId = req.params.userId;
-    const token = req.params.token;
+    const userId = req.body.userId;
+    const token = req.body.token;
 
     log.info('Call controller function to check if the requested user exists or not');
     const userInfo = await accountController.getUserInfoById(userId);


### PR DESCRIPTION
## Description
- This PR introduces a Forgot Password API to initiate secure password reset flows and updates the Verify Email API to follow a cleaner, payload-based contract.
### New API Endpoint
- Forgot Password
  POST /api/v1.0/auth/password/forgot
### Request Payload
| Field            | Description                      | Required |
| ---------------- | -------------------------------- | -------- |
| `userIdentifier` | Username or email ID of the user | Yes      |
### Response Payload
- No response body (HTTP 200 OK)
  A successful response does not indicate whether the user exists, helping prevent user enumeration.
### API Flow & Logic
1. Input Validation
    - Validates the userIdentifier format (username or email).
    - Returns 400 Bad Request for invalid patterns.
2. Immediate Response
    - Returns 200 OK once validation passes.
    - Prevents disclosure of user existence.
3. Forgot Password Processing
    - Identifies the user using the provided username or email ID.
    - Generates:
      - Forgot password verification code
      - Expiry timestamp (valid for 30 minutes)
    - Builds user payload and user context.
4. Asynchronous Email Trigger
    - Publishes the forgot-password task to the email queue.
    - Email service consumes the task and sends the reset email to the user.
### Updated API Endpoint
- Verify Email
  Old: PUT /auth/verify-email/:userId/:token
  New: POST /auth/verify/email
### Updated Request Payload
| Field    | Description                   | Required |
| -------- | ----------------------------- | -------- |
| `userId` | Unique identifier of the user | Yes      |
| `token`  | Email verification token      | Yes      |
### Key Highlights
- Secure forgot-password initiation flow
- Prevents user enumeration attacks
- Asynchronous email handling via queue
- Cleaner verify-email API contract
- Consistent auth route structure